### PR TITLE
BUG: Incorrect case for license family

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,6 @@ about:
   home: http://github.com/marshallward/f90nml
   license: Apache-2.0
   summary: 'Fortran 90 namelist parser'
-  license_family: Apache
   license_file: LICENSE
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,6 @@ requirements:
     - python
 
 test:
-  # Python imports
   imports:
     - f90nml
 
@@ -31,7 +30,7 @@ about:
   home: http://github.com/marshallward/f90nml
   license: Apache-2.0
   summary: 'Fortran 90 namelist parser'
-  license_family: APACHE
+  license_family: Apache
   license_file: LICENSE
 
 extra:


### PR DESCRIPTION
My bad.  Incorrect case for license family.  Should be Apache, not APACHE.

```python
...
  File "/path/to/env/lib/python3.5/site-packages/conda_build/metadata.py", line 163, in ensure_valid_license_family
    (license_family, comma_join(sorted(allowed_license_families)))))
RuntimeError: about/license_family 'APACHE' not allowed. Allowed families are AGPL,
Apache, BSD, GPL, GPL2, GPL3, LGPL, MIT, Other, PSF, Proprietary, and
Public-Domain.
Aborted!
```